### PR TITLE
fix warnings when using <br/> separator

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -32,6 +32,16 @@ Comma-separated — array of strings:
 <Group separator=", " children={['One', 'Two', 'Three']} />
 ```
 
+React element-separated — React elements:
+
+```
+<Group separator={<br />}>
+	<a href="#">One</a>
+	<a href="#">Two</a>
+	<a href="#">Three</a>
+</Group>
+```
+
 Inline:
 
 ```

--- a/index.js
+++ b/index.js
@@ -17,10 +17,16 @@ function Group(props) {
 
 	// Insert separators
 	var items = children;
+	var separator = props.separator;
+	var separatorIsElement = React.isValidElement(separator);
 	if (children.length > 1) {
 		items = [children.shift()];
-		children.forEach(function(item) {
-			return items.push(props.separator, item);
+		children.forEach(function(item, index) {
+			if (separatorIsElement) {
+				var key = 'separator-' + (item.key || index);
+				separator = React.cloneElement(separator, { key: key });
+			}
+			return items.push(separator, item);
 		});
 	}
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -30,6 +30,19 @@ test('should render three button separated by a custom separator', () => {
 	expect(actual.text()).toEqual('One:Two:Three');
 });
 
+test('should render three button separated by react element <br/>', () => {
+	const originalErrorLog = console.error;
+	console.error = jest.genMockFn();
+
+	const actual = shallow(
+		createElement(Group, { separator: React.createElement('br') }, elements)
+	);
+
+	expect(console.error).not.toBeCalled();
+	expect(actual.find('br').length).toEqual(2);
+	console.error = originalErrorLog;
+});
+
 test('should render array of strings', () => {
 	const actual = shallow(
 		createElement(Group, {}, strings)

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	title: 'React Group',
 	components: './index.js',
-	getExampleFilename: () => './examples.md',
+	getExampleFilename: () => __dirname + '/examples.md',
 	getComponentPathLine: () => "import Group from 'react-group';",
 	showCode: true,
 	styleguideDir: './docs',


### PR DESCRIPTION
Hi,

there is react unique key warnings when using the latest react-styleguidist@4.6.3 due to the break element separator passed to ```Group```
the styleguidist isn't running (```npm start```) as it is unable to resolve ```./examples.md```, added additional fix.

```
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Group`. It was passed a child from PreviewComponent. See https://fb.me/react-warning-keys for more information.
    in br (created by PreviewComponent)
    in Group (created by PreviewComponent)
    in PreviewComponent
    in Wrapper
```

this PR fixes that.
